### PR TITLE
Add Ruby 3.4 and Rails 8.0 to CI matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -15,8 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3"]
-        gemfile: ["rails71", "rails72"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        gemfile: ["rails71", "rails72", "rails80"]
+        exclude:
+          # rails 8.0: support ruby 3.2+
+          - ruby: "3.1"
+            gemfile: "rails80"
     steps:
       - uses: actions/checkout@v4
 

--- a/csb.gemspec
+++ b/csb.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "ostruct"
 end

--- a/gemfiles/rails80.gemfile
+++ b/gemfiles/rails80.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gem 'rails', '~> 8.0.0'
+
+gemspec path: '../'


### PR DESCRIPTION
This Pull Request adds Ruby 3.4 and Rails 8.0 to the CI matrix.

Additionally, it adds `ostruct` to the development dependencies to address the following warning, which appears when running tests with Ruby 3.4:

```
/path/csb/spec/lib/csb/builder_spec.rb:1: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```
