### PR TITLE
CI: Add Ruby 4.0 and Rails 8.1 to CI Matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,11 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.1", "3.2", "3.3", "3.4", "4.0"]
-        gemfile: ["rails71", "rails72", "rails80"]
+        gemfile: ["rails71", "rails72", "rails80", "rails81"]
         exclude:
           # rails 8.0: support ruby 3.2+
           - ruby: "3.1"
             gemfile: "rails80"
+          # rails 8.1: support ruby 3.2+
+          - ruby: "3.1"
+            gemfile: "rails81"
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,14 +16,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "4.0"]
         gemfile: ["rails71", "rails72", "rails80"]
         exclude:
           # rails 8.0: support ruby 3.2+
           - ruby: "3.1"
             gemfile: "rails80"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/csb.gemspec
+++ b/csb.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 7.1.4"
   spec.add_dependency "csv"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "ostruct"

--- a/gemfiles/rails81.gemfile
+++ b/gemfiles/rails81.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gem 'rails', '~> 8.1.0'
+
+gemspec path: '../'

--- a/lib/csb/railtie.rb
+++ b/lib/csb/railtie.rb
@@ -1,4 +1,4 @@
-require 'rails/railtie'
+require 'rails'
 
 module Csb
   class Railtie < Rails::Railtie


### PR DESCRIPTION
This Pull Request adds Ruby 4.0 and Rails 8.1 to the CI Matrix.

It also includes the following changes:
- Remove the bundler gem from development dependencies for Bundler 4.0 (Ruby 4.0)
- Fix NoMethodError with Rails 8.1
- Bump actions/checkout from 4 to 6

### Fix NoMethodError with Rails 8.1
To fix the following error that occurs with Rails 8.1, this Pull Request replaces `require 'rails/railtie'` with `require 'rails'`.

The reason for switching to require 'rails' is based on the following discussion:
> So, in order to require rails/railtie you should require 'rails`. That is correct.
https://github.com/rails/rails/issues/55970#issuecomment-3433908316

Below are the details of the error that occurs:
```sh
$ bundle exec rake
An error occurred while loading spec_helper.
Failure/Error: require 'rails/railtie'

NoMethodError:
  undefined method 'delegate_missing_to' for class Rails::Initializable::Collection
# ./tmp/ruby/4.0.0/gems/railties-8.1.2/lib/rails/initializable.rb:41:in '<class:Collection>'
# ./tmp/ruby/4.0.0/gems/railties-8.1.2/lib/rails/initializable.rb:37:in '<module:Initializable>'
# ./tmp/ruby/4.0.0/gems/railties-8.1.2/lib/rails/initializable.rb:6:in '<module:Rails>'
# ./tmp/ruby/4.0.0/gems/railties-8.1.2/lib/rails/initializable.rb:5:in '<top (required)>'
# ./tmp/ruby/4.0.0/gems/railties-8.1.2/lib/rails/railtie.rb:3:in '<top (required)>'
# ./lib/csb/railtie.rb:1:in '<top (required)>'
# ./lib/csb.rb:2:in '<top (required)>'
# ./spec/spec_helper.rb:2:in '<top (required)>'
No examples found.
...
```
